### PR TITLE
Return the last title / segment set which is great for page headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add the following to you `config/app.php`
 #### Set one or more segments
 
     Title::segment('Foo', 'Bar');
-
+     
 #### Make the title
 
     Title::make();
@@ -46,6 +46,9 @@ Add the following to you `config/app.php`
 
     Title::layout('%s - %s');
 
+#### Return Last Segment
+
+    Title::last();   
 
 Running the `siteName` and `segment` methods with the above properties (and the default layout), would cause `make` to output the following
 

--- a/src/Models/Title.php
+++ b/src/Models/Title.php
@@ -34,6 +34,16 @@ class Title {
     }
 
     /**
+     * Returns last added segment
+     *
+     * @return string
+     */
+    public function last()
+    {
+        return end($this->segments);
+    }
+
+    /**
      * Override the layout
      *
      * @return void

--- a/tests/TitleTest.php
+++ b/tests/TitleTest.php
@@ -50,6 +50,15 @@ class TitleTest extends PHPUnit_Framework_TestCase {
         $this->assertSame($title->make(), 'Foo | Bar | Baz');
     }
 
+    public function testCanReturnLast()
+    {
+        $title = new Title($this->config);
+
+        $title->segment('Foo', 'Bar', 'Baz');
+
+        $this->assertSame($title->last(), 'Baz');
+    }
+
     public function testCanSetFullTitle()
     {
         $title = new Title($this->config);


### PR DESCRIPTION
I find this feature very useful.  I didn't now where to place it in the readme though.