### PR TITLE
Changed from bind to singleton

### DIFF
--- a/src/TitleServiceProvider.php
+++ b/src/TitleServiceProvider.php
@@ -31,7 +31,7 @@ class TitleServiceProvider extends ServiceProvider
      */
     protected function bindRepositories()
     {
-        $this->app->bind('Title', function ($app) {
+        $this->app->singleton('Title', function ($app) {
             return new Models\Title($app['config']);
         });
     }


### PR DESCRIPTION
When accessing the lib via `$this->app` (or injecting) you get a new instance every time. Changed to singleton so it functions the same as the Facade.